### PR TITLE
Using `git remote show` instead of `git remote get-url`

### DIFF
--- a/vapor.swift
+++ b/vapor.swift
@@ -843,7 +843,7 @@ extension Heroku {
             print("Setting up Heroku for \(packageName) ...")
             print()
 
-            let herokuIsAlreadyInitialized = passes("git remote get-url heroku")
+            let herokuIsAlreadyInitialized = passes("git remote show heroku")
             if herokuIsAlreadyInitialized {
                 print("Found existing heroku app")
                 print()


### PR DESCRIPTION
Using `remote show` instead of `remote get-url`.

`get-url` was [introduced](https://github.com/git/git/blob/master/Documentation/RelNotes/2.7.0.txt) in git 2.7, which makes `vapor heroku init` fail on vanilla git installed on Mac OSX el capitan (mine was 2.6.1).

Note: I couldn't find when `remote show` was added to git, but its before [git 1.5 ](https://github.com/git/git/blob/c2c5f6b1e479f2c38e0e01345350620944e3527f/Documentation/RelNotes/1.5.1.txt) (Sep 2010)